### PR TITLE
Feat: 마이페이지 남은 API 연결

### DIFF
--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -3,6 +3,7 @@ import { getCookie, refreshCookie } from './cookie';
 
 /**
  * @param instance 실제 api 연결 시 사용되는 instance입니다.
+ * @param instanceNoToken api 연결 시 토큰이 필요 없을 때 사용합니다.
  */
 
 export const instanceTest = axios.create({

--- a/src/apis/deleteMember.ts
+++ b/src/apis/deleteMember.ts
@@ -1,0 +1,15 @@
+import instance from './axios';
+
+interface DeleteMemberProps {
+	reason: string | null;
+}
+export const deleteMember = async (data: DeleteMemberProps) => {
+	try {
+		const res = await instance.delete('/users', {
+			data: data,
+		});
+	} catch (err) {
+		console.error(err);
+		throw new Error('회원 탈퇴 실패');
+	}
+};

--- a/src/apis/putNickname.ts
+++ b/src/apis/putNickname.ts
@@ -1,0 +1,15 @@
+import instance from './axios';
+
+interface PutNickNameProps {
+	nickname: string;
+}
+
+export const putNickName = async (data: PutNickNameProps) => {
+	try {
+		const res = await instance.put('/users/me', data);
+		return res.data;
+	} catch (err) {
+		console.error(err);
+		throw new Error('닉네임 수정 실패');
+	}
+};

--- a/src/apis/wishes.ts
+++ b/src/apis/wishes.ts
@@ -2,7 +2,7 @@ import axios from './axios';
 
 export const getWishes = async () => {
 	try {
-		const res = await axios.get('api/wwwww'); // 임시 수정
+		const res = await axios.get('/products/wish'); // 임시 수정
 		if (res) {
 			return res.data;
 		}

--- a/src/data/regionData.ts
+++ b/src/data/regionData.ts
@@ -6,7 +6,7 @@ export const regionData = [
 	},
 	{
 		id: 2,
-		region: '경기도',
+		region: '경기',
 		areaCode: 'GYEONGGI',
 	},
 	{

--- a/src/pages/mypage/component/account/ManageAccount.tsx
+++ b/src/pages/mypage/component/account/ManageAccount.tsx
@@ -66,32 +66,26 @@ const ManageAccount = () => {
 			</BottomSheet>
 			<div className="w-full flex flex-col items-center">
 				<div className="w-[90%] mt-5 flex flex-col">
-					<div className="flex flex-row justify-between mb-5">
+					<div
+						className="flex flex-row justify-between mb-5 cursor-pointer"
+						onClick={editPasswordBtn}
+					>
 						<span>비밀번호 변경</span>
-						<img
-							className="cursor-pointer"
-							src="/assets/images/rightArrowTab.svg"
-							alt="탭 이동"
-							onClick={editPasswordBtn}
-						/>
+						<img src="/assets/images/rightArrowTab.svg" alt="탭 이동" />
 					</div>
-					<div className="flex flex-row justify-between mb-5">
+					<div
+						className="flex flex-row justify-between mb-5 cursor-pointer"
+						onClick={openBottomSheetSignOut}
+					>
 						<span>로그아웃</span>
-						<img
-							className="cursor-pointer"
-							src="/assets/images/rightArrowTab.svg"
-							alt="탭 이동"
-							onClick={openBottomSheetSignOut}
-						/>
+						<img src="/assets/images/rightArrowTab.svg" alt="탭 이동" />
 					</div>
-					<div className="flex flex-row justify-between mb-5">
+					<div
+						className="flex flex-row justify-between mb-5 cursor-pointer"
+						onClick={withdrawlBtn}
+					>
 						<span>회원탈퇴</span>
-						<img
-							className="cursor-pointer"
-							src="/assets/images/rightArrowTab.svg"
-							alt="탭 이동"
-							onClick={withdrawlBtn}
-						/>
+						<img src="/assets/images/rightArrowTab.svg" alt="탭 이동" />
 					</div>
 				</div>
 			</div>

--- a/src/pages/mypage/component/btn/MyPageClickBtn.tsx
+++ b/src/pages/mypage/component/btn/MyPageClickBtn.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 export interface MyPageClickBtnProps {
 	content: string;
 	onClick?: () => void;
-	isDisabled?: boolean;
+	isDisabled?: boolean | undefined;
 }
 
 const MyPageClickBtn = ({

--- a/src/pages/mypage/component/edit/ProfileEdit.tsx
+++ b/src/pages/mypage/component/edit/ProfileEdit.tsx
@@ -1,11 +1,54 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Header } from '../../../../component/common/Header';
 import MyPageClickBtn from '../btn/MyPageClickBtn';
+import { useForm } from 'react-hook-form';
+import { useMutation } from '@tanstack/react-query';
+import { putNickName } from '../../../../apis/putNickname';
+import { useNavigate } from 'react-router';
+import { getNickName } from '../../../../apis/nickname';
 
 const ProfileEdit = () => {
-	const handleEditProfile = () => {
-		alert('프로필 수정 완료');
+	const {
+		register,
+		handleSubmit,
+		watch,
+		setValue,
+		formState: { errors }, // isSubmitting, isDirty, isValid
+	} = useForm({ mode: 'onChange' });
+	const navigate = useNavigate();
+	const myProfileJSON = localStorage.getItem('userProfileInfo');
+	const myProfile = JSON.parse(myProfileJSON as string);
+	const [myNicknameAvailable, setMyNickNameAvailable] = useState(null);
+	const currentNickName = watch('currentNickName');
+	useEffect(() => {
+		setValue('currentNickName', myProfile.data.nickname);
+	}, [myProfile.data.nickname, setValue]);
+
+	const mutation = useMutation({
+		mutationFn: putNickName,
+		onSuccess() {
+			alert('프로필 수정 성공');
+			navigate('/');
+		},
+	});
+
+	const handleCheckNickName = async () => {
+		const res = await getNickName(currentNickName);
+		setMyNickNameAvailable(res.data);
+		console.log(res.data);
 	};
+
+	const handleProfileEdit = () => {
+		const data = { nickname: currentNickName };
+		mutation.mutate(data);
+	};
+
+	useEffect(() => {
+		if (currentNickName === '') {
+			setMyNickNameAvailable(null);
+		}
+	}, [currentNickName]);
+	console.log(myNicknameAvailable);
 	return (
 		<div>
 			<Header title="프로필 수정" />
@@ -19,27 +62,71 @@ const ProfileEdit = () => {
 								<button
 									className="border border-borderGray absolute cursor-pointer right-2 top-[2.5rem] w-14 h-6 bg-borderGray text-sm text-[#828282] rounded-md"
 									type="button"
+									onClick={handleCheckNickName}
 								>
 									중복 확인
 								</button>
 							</div>
 							<input
-								className="w-full h-11 rounded-xl text-lg mt-2 bg-lightGray pl-4 focus:outline-none"
+								className={`border ${
+									currentNickName &&
+									myNicknameAvailable !== null &&
+									!myNicknameAvailable
+										? 'border-green'
+										: 'border-borderGray'
+								} w-full h-11 rounded-xl text-botton mt-2 bg-lightGray pl-4 focus:outline-none ${
+									(currentNickName && errors.email) || myNicknameAvailable
+										? 'border border-red'
+										: ''
+								}`}
 								type="text"
-								placeholder="원래 이름"
+								{...register('currentNickName', {
+									required: true,
+									pattern: {
+										value: /^[가-힣a-zA-Z0-9]*$/,
+										message:
+											'특수문자와 띄어쓰기를 제외한 한글, 영문, 숫자로 닉네임을 작성해주세요.',
+									},
+								})}
 							/>
 						</div>
+						{myNicknameAvailable === null ? (
+							<div className="text-sm mb-4 text-start text-red">
+								{errors?.currentNickName?.message as string}
+							</div>
+						) : myNicknameAvailable ? (
+							<div className="text-sm mb-4 text-start text-red">
+								중복된 닉네임입니다.
+							</div>
+						) : (
+							<div className="text-sm mb-4 text-start text-green">
+								사용가능한 닉네임입니다.
+							</div>
+						)}
 						<div className="mt-7">
 							<div className="flex flex-row justify-between font-bold">
 								<p className="text-lg">휴대폰 번호</p>
 							</div>
 							<div className="w-full h-11 rounded-xl text-botton mt-2 bg-lightGray pl-4 focus:outline-none">
-								<p className="pt-2 text-start text-gray">010-1234-5678</p>
+								<p className="pt-2 text-start text-gray">
+									{myProfile.data.phoneNumber}
+								</p>
+							</div>
+						</div>
+						<div className="mt-7">
+							<div className="flex flex-row justify-between font-bold">
+								<p className="text-lg">이메일</p>
+							</div>
+							<div className="w-full h-11 rounded-xl text-botton mt-2 bg-lightGray pl-4 focus:outline-none">
+								<p className="pt-2 text-start text-gray">
+									{myProfile.data.email}
+								</p>
 							</div>
 						</div>
 						<MyPageClickBtn
 							content="변경사항 저장하기"
-							onClick={handleEditProfile}
+							onClick={handleProfileEdit}
+							isDisabled={!myNicknameAvailable}
 						/>
 					</form>
 				</div>

--- a/src/pages/mypage/component/region/InterestRegion.tsx
+++ b/src/pages/mypage/component/region/InterestRegion.tsx
@@ -60,10 +60,6 @@ const InterestRegion = () => {
 			mutation.mutate({ regions: selectedList });
 		}
 	};
-	// const handleRefreshToken = () => {
-	// 	const refreshToken = getCookie('refreshToken');
-	// 	refreshCookie(refreshToken);
-	// };
 	return (
 		<div>
 			<Header title="관심 지역" />
@@ -79,18 +75,13 @@ const InterestRegion = () => {
 					<p>관심 지역을 설정해 두시면 알림을 보내드려요!</p>
 					<p>관심지역은 3개까지 추가 가능합니다.</p>
 				</div>
-				<div className="w-[90%] flex flex-row justify-between rounded-lg bg-lightGray mx-auto mt-5 p-3 text-gray">
+				<div
+					className="w-[90%] flex flex-row justify-between rounded-lg bg-lightGray mx-auto mt-5 p-3 text-gray cursor-pointer"
+					onClick={openBottomSheet}
+				>
 					<p>관심지역을 선택해주세요.</p>
-					<img
-						className="cursor-pointer"
-						src="/assets/images/dropdownArrow.svg"
-						alt="아래로 이동"
-						onClick={openBottomSheet}
-					/>
+					<img src="/assets/images/dropdownArrow.svg" alt="아래로 이동" />
 				</div>
-				{/* <button className="border" onClick={handleRefreshToken}>
-					토큰 재발급
-				</button> */}
 				{convertedWishRegions &&
 					convertedWishRegions.map((region: WishRegionProps) => (
 						<div

--- a/src/pages/mypage/component/region/SelectBanks.tsx
+++ b/src/pages/mypage/component/region/SelectBanks.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useRecoilState } from 'recoil';
 import { SelectBanksProps, checkedBankState } from '../../../../recoil/atom';
 import { bankData } from '../../../../data/bankData';
-interface CloseFuncProps {
+export interface CloseFuncProps {
 	closeFunc: () => void;
 }
 const SelectBanks = ({ closeFunc }: CloseFuncProps) => {

--- a/src/pages/mypage/component/signIn/AfterSignInMyPage.tsx
+++ b/src/pages/mypage/component/signIn/AfterSignInMyPage.tsx
@@ -6,7 +6,7 @@ const AfterSignInMyPage = () => {
 	const myProfile = JSON.parse(myProfileJSON as string);
 	return (
 		<div className="flex flex-col items-center w-full h-screen text-center">
-			<div className="mt-8 font-medium">마이페이지</div>
+			<div className="mt-8 font-medium cursor-default">마이페이지</div>
 			<div className="mt-11 text-start w-[90%] text-descGray">
 				<div className="flex flex-row gap-6">
 					<img
@@ -14,123 +14,130 @@ const AfterSignInMyPage = () => {
 						src="/assets/images/profileImage.svg"
 					/>
 					<div className="mt-2 text-descGray flex flex-col">
-						<p className="text-headline2 text-black font-semibold">
+						<p className="text-headline2 text-black font-semibold cursor-default">
 							{myProfile.data.nickname}
 						</p>
-						<div className="flex flex-row gap-1">
-							<span className="text-body">프로필 수정</span>
-							<Link to="/mypage/editprofile">
+						<Link to="/mypage/editprofile">
+							<div className="flex flex-row gap-1">
+								<span className="text-body">프로필 수정</span>
+
 								<img
 									className="cursor-pointer w-4 h-4 mt-1"
 									src="/assets/images/rightArrow.svg"
 									alt="프로필 수정"
 								/>
-							</Link>
-						</div>
+							</div>
+						</Link>
 					</div>
 				</div>
 			</div>
 			<div className="border border-borderWhite bg-borderWhite w-full h-2 mt-5"></div>
 			<div className="w-[90%] mt-5 flex flex-col">
 				<div className="flex flex-row justify-between mb-2">
-					<span className="font-semibold text-lg">MY</span>
+					<span className="font-semibold text-lg cursor-default">MY</span>
 				</div>
-				<div className="flex flex-row justify-between mb-5">
-					<span>판매내역</span>
-					<Link to="/sales">
+				<Link to="/sales">
+					<div className="flex flex-row justify-between mb-5">
+						<span>판매내역</span>
+
 						<img
-							className="cursor-pointer mt-1"
+							className="cursor-pointer"
 							src="/assets/images/rightArrowTab.svg"
 							alt="탭 이동"
 						/>
-					</Link>
-				</div>
-				<div className="flex flex-row justify-between mb-5">
-					<span>구매내역</span>
-					<Link to="/purchase">
+					</div>
+				</Link>
+				<Link to="/purchase">
+					<div className="flex flex-row justify-between mb-5">
+						<span>구매내역</span>
 						<img
-							className="cursor-pointer mt-1"
+							className="cursor-pointer"
 							src="/assets/images/rightArrowTab.svg"
 							alt="탭 이동"
 						/>
-					</Link>
-				</div>
-				<div className="flex flex-row justify-between mb-5">
-					<span>찜한 상품</span>
-					<Link to="/mypage/wishes">
+					</div>
+				</Link>
+				<Link to="/mypage/wishes">
+					<div className="flex flex-row justify-between mb-5">
+						<span>찜한 상품</span>
 						<img
-							className="cursor-pointer mt-1"
+							className="cursor-pointer"
 							src="/assets/images/rightArrowTab.svg"
 							alt="탭 이동"
 						/>
-					</Link>
-				</div>
-				<div className="flex flex-row justify-between mb-5">
-					<span>관심지역</span>
-					<Link to="/mypage/mylocations">
+					</div>
+				</Link>
+				<Link to="/mypage/mylocations">
+					<div className="flex flex-row justify-between mb-5">
+						<span>관심지역</span>
+
 						<img
-							className="cursor-pointer mt-1"
+							className="cursor-pointer"
 							src="/assets/images/rightArrowTab.svg"
 							alt="탭 이동"
 						/>
-					</Link>
-				</div>
+					</div>
+				</Link>
 				<div className="flex flex-row justify-between mt-1 mb-1">
-					<span className="font-semibold text-lg">관리</span>
+					<span className="font-semibold text-lg cursor-default">관리</span>
 				</div>
-				<div className="flex flex-row justify-between mb-5">
-					<span>내 계좌</span>
-					<Link to="/myaccount">
+				<Link to="/myaccount">
+					<div className="flex flex-row justify-between mb-5">
+						<span>내 계좌</span>
+
 						<img
-							className="cursor-pointer mt-1"
+							className="cursor-pointer"
 							src="/assets/images/rightArrowTab.svg"
 							alt="탭 이동"
 						/>
-					</Link>
-				</div>
-				<div className="flex flex-row justify-between mb-5">
-					<span>계정관리</span>
-					<Link to="/member">
+					</div>
+				</Link>
+				<Link to="/member">
+					<div className="flex flex-row justify-between mb-5">
+						<span>계정관리</span>
+
 						<img
-							className="cursor-pointer mt-1"
+							className="cursor-pointer"
 							src="/assets/images/rightArrowTab.svg"
 							alt="탭 이동"
 						/>
-					</Link>
-				</div>
+					</div>
+				</Link>
 				<div className="flex flex-row justify-between mt-1 mb-1">
-					<span className="font-semibold text-lg">서비스</span>
+					<span className="font-semibold text-lg cursor-default">서비스</span>
 				</div>
-				<div className="flex flex-row justify-between mb-5">
-					<span>공지사항</span>
-					<Link to="/mypage/announcement">
+				<Link to="/mypage/announcement">
+					<div className="flex flex-row justify-between mb-5">
+						<span>공지사항</span>
 						<img
-							className="cursor-pointer mt-1"
+							className="cursor-pointer"
 							src="/assets/images/rightArrowTab.svg"
 							alt="탭 이동"
 						/>
-					</Link>
-				</div>
-				<div className="flex flex-row justify-between mb-5">
-					<span>개인정보 처리방침</span>
-					<Link to="/mypage/guide">
+					</div>
+				</Link>
+				<Link to="/mypage/guide">
+					<div className="flex flex-row justify-between mb-5">
+						<span>개인정보 처리방침</span>
+
 						<img
-							className="cursor-pointer mt-1"
+							className="cursor-pointer"
 							src="/assets/images/rightArrowTab.svg"
 							alt="탭 이동"
 						/>
-					</Link>
-				</div>
-				<div className="flex flex-row justify-between">
-					<span>서비스 이용약관 및 정책</span>
-					<Link to="/mypage/guide">
+					</div>
+				</Link>
+				<Link to="/mypage/guide">
+					<div className="flex flex-row justify-between">
+						<span>서비스 이용약관 및 정책</span>
+
 						<img
-							className="cursor-pointer mt-1"
+							className="cursor-pointer"
 							src="/assets/images/rightArrowTab.svg"
 							alt="탭 이동"
 						/>
-					</Link>
-				</div>
+					</div>
+				</Link>
 			</div>
 		</div>
 	);

--- a/src/pages/mypage/component/signIn/BeforeSignInMyPage.tsx
+++ b/src/pages/mypage/component/signIn/BeforeSignInMyPage.tsx
@@ -3,57 +3,62 @@ import { Link } from 'react-router-dom';
 const BeforeSignInMyPage = () => {
 	return (
 		<div className="flex flex-col items-center w-full h-screen text-center">
-			<div className="mt-8">마이페이지</div>
-			<div className="mt-11 text-start w-[90%] text-descGray text-body">
+			<div className="mt-8 cursor-default">마이페이지</div>
+			<div className="mt-11 text-start w-[90%] text-descGray text-body cursor-default">
 				<p>로그인하고</p>
 				<p>
 					간편하고 안전한 <span className="text-main">골든티켓</span>{' '}
 					이용해보세요!
 				</p>
-				<div className="mt-2 text-headline2 text-black flex flex-row gap-1 h-6">
-					<span>로그인 하기</span>
-					<Link to="/signin">
+				<Link to="/signin">
+					<div className="mt-2 text-headline2 text-black flex flex-row gap-1 h-6">
+						<span>로그인 하기</span>
+
 						<img
 							className="cursor-pointer mt-1 h-5"
 							src="/assets/images/rightArrow.svg"
 							alt="로그인 하기"
 						/>
-					</Link>
-				</div>
+					</div>
+				</Link>
 			</div>
 			<div className="border border-borderWhite bg-borderWhite w-full h-2 mt-5"></div>
 			<div className="w-[90%] mt-5 flex flex-col text-lg">
 				<div className="flex flex-row justify-between mb-2">
-					<span className="font-semibold">서비스</span>
+					<span className="font-semibold cursor-default">서비스</span>
 				</div>
-				<div className="flex flex-row justify-between mb-5">
-					<span>공지사항</span>
-					<Link to="/mypage/announcement">
+				<Link to="/mypage/announcement">
+					<div className="flex flex-row justify-between mb-5">
+						<span>공지사항</span>
+
 						<img
-							className="cursor-pointer mt-1"
+							className="cursor-pointer"
 							src="/assets/images/rightArrowTab.svg"
 							alt="탭 이동"
 						/>
-					</Link>
-				</div>
-				<div className="flex flex-row justify-between mb-5">
-					<span>개인정보 처리방침</span>
-					<Link to="/mypage/guide">
+					</div>
+				</Link>
+				<Link to="/mypage/guide">
+					<div className="flex flex-row justify-between mb-5">
+						<span>개인정보 처리방침</span>
+
 						<img
-							className="cursor-pointer mt-1"
+							className="cursor-pointer"
 							src="/assets/images/rightArrowTab.svg"
 							alt="탭 이동"
 						/>
-					</Link>
-				</div>
-				<div className="flex flex-row justify-between">
-					<span>서비스 이용약관 및 정책</span>
-					<img
-						className="cursor-pointer mt-1"
-						src="/assets/images/rightArrowTab.svg"
-						alt="탭 이동"
-					/>
-				</div>
+					</div>
+				</Link>
+				<Link to="/mypage/guid">
+					<div className="flex flex-row justify-between">
+						<span>서비스 이용약관 및 정책</span>
+						<img
+							className="cursor-pointer"
+							src="/assets/images/rightArrowTab.svg"
+							alt="탭 이동"
+						/>
+					</div>
+				</Link>
 			</div>
 		</div>
 	);

--- a/src/pages/mypage/component/wishes/WishItem.tsx
+++ b/src/pages/mypage/component/wishes/WishItem.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { formatDate } from '../../../../utils/b';
+export interface WishItemProps {
+	accommodationImage: string;
+	accommodationName: string;
+	checkInDate: string;
+	checkOutDate: string;
+	dDay: number;
+	goldenPrice: number;
+	id: number;
+	nights: number;
+	originPrice: number;
+	productId: number;
+	roomName: string;
+	status: string;
+	type: string;
+	yanoljaPrice: number;
+}
+export const WishItem = ({ product }: { product: WishItemProps }) => {
+	return (
+		<div className="flex h-[95px]">
+			<div className="relative mb-2 h-full">
+				<img
+					className="w-[120px] h-[95px] rounded-[5px]"
+					src={product.accommodationImage}
+					alt="productImg"
+				/>
+				<div className="flex bg-dateBlue px-[6px] py-[4px] absolute top-0 rounded-tl-[5px] rounded-br-[5px]">
+					<p className="text-white font-pre text-[8px] font-semibold mr-1">
+						{`${formatDate(product.checkInDate)} ~ ${formatDate(
+							product.checkOutDate,
+						)}`}
+					</p>
+					<p className="text-white font-pre text-[8px] font-semibold">
+						D-{product.dDay}
+					</p>
+				</div>
+				<button className="absolute bottom-[10px] left-[10px]">
+					<img src={`/assets/images/fillheart_white.svg`} alt="heartIcon" />
+				</button>
+			</div>
+			<div className="flex flex-col w-[60%] justify-between ml-4">
+				<div className="flex-col w-full">
+					<div>
+						<p className="text-fontBlack font-pre text-lg font-normal">
+							{product.accommodationName}
+						</p>
+						<p className="text-fontBlack font-pre text-lg font-normal">
+							{product.roomName}
+						</p>
+					</div>
+				</div>
+				<div>
+					<div className="flex justify-between w-[100%]">
+						<p className="text-descGray font-pre text-m">현재 야놀자 판매가</p>
+						<div className="flex">
+							<p className="text-descGray font-pre text-m mr-1">
+								{(
+									(1 - product.goldenPrice / product.yanoljaPrice) *
+									100
+								).toFixed(0)}
+								%
+							</p>
+							<p className="text-descGray font-pre text-m line-through">
+								{product.yanoljaPrice.toLocaleString()}
+							</p>
+							<p className="text-descGray font-pre text-m line-through">원</p>
+						</div>
+					</div>
+					<div className="flex justify-between w-[100%]">
+						<p className="text-descGray font-pre text-m">기존 구매가</p>
+						<div className="flex">
+							<p className="text-descGray font-pre text-m mr-1">
+								{' '}
+								{(
+									(1 - product.goldenPrice / product.originPrice) *
+									100
+								).toFixed(0)}
+								%
+							</p>
+							<p className="text-descGray font-pre text-m line-through">
+								{product.originPrice.toLocaleString()}
+							</p>
+							<p className="text-descGray font-pre text-m line-through">원</p>
+						</div>
+					</div>
+					<div className="flex justify-between w-[100%]">
+						<p className="text-fontBlack font-pre text-m font-semibold">
+							골든 특가
+						</p>
+						<div className="flex">
+							<p className="text-fontBlack font-pre text-m font-semibold">
+								{product.goldenPrice.toLocaleString()}
+							</p>
+							<p className="text-fontBlack font-pre text-m font-semibold">원</p>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/src/pages/mypage/component/wishes/WishList.tsx
+++ b/src/pages/mypage/component/wishes/WishList.tsx
@@ -4,20 +4,36 @@ import { useQuery } from '@tanstack/react-query';
 import { getWishes } from '../../../../apis/wishes';
 import { ProductSpecialType } from '../../../main/component/Product/ProductListSpecial';
 import { Header } from '../../../../component/common/Header';
+import { WishItem, WishItemProps } from './WishItem';
 
+export interface WishListProps {
+	accommodationImage: string;
+	accommodationName: string;
+	checkInDate: string;
+	checkOutDate: string;
+	dDay: number;
+	goldenPrice: number;
+	id: number;
+	nights: number;
+	originPrice: number;
+	productId: number;
+	roomName: string;
+	status: string;
+	type: string;
+	yanoljaPrice: number;
+}
 const WishList = () => {
 	const { data } = useQuery({
 		queryKey: ['wishes'],
 		queryFn: getWishes,
 	});
-	console.log(data);
 	return (
 		<div>
 			<Header title="찜한 상품" />
-			{data &&
-				data.map((item: ProductSpecialType) => (
-					<div key={item.productId} className="w-[95%] mt-11 mb-7 mx-auto">
-						<ProductItemNew key={item.productId} product={item} />
+			{data?.data?.wishProducts &&
+				data?.data?.wishProducts.map((item: WishItemProps) => (
+					<div key={item.id} className="w-[95%] mt-11 mb-7 mx-auto">
+						<WishItem key={item.id} product={item} />
 					</div>
 				))}
 		</div>

--- a/src/pages/mypage/component/withDrawl/Withdrawal.tsx
+++ b/src/pages/mypage/component/withDrawl/Withdrawal.tsx
@@ -4,12 +4,25 @@ import BottomSheet from '../../../../component/common/BottomSheet/BottomSheet';
 import WithdrawlReasons from './WithdrawlReasons';
 import { useNavigate } from 'react-router-dom';
 import MyPageClickBtn from '../btn/MyPageClickBtn';
+import { useRecoilValue } from 'recoil';
+import { withDrawlState } from '../../../../recoil/atom';
+import { useMutation } from '@tanstack/react-query';
+import { deleteMember } from '../../../../apis/deleteMember';
+import { deleteCookie } from '../../../../apis/cookie';
 
 const Withdrawl = () => {
 	const navigate = useNavigate();
+	const selectReason = useRecoilValue(withDrawlState);
 	const [isBottomSheetOpenWithDrawl, setIsBottomSheetWithDrawlOpen] =
 		useState(false);
 
+	const mutation = useMutation({
+		mutationFn: deleteMember,
+		onSuccess() {
+			deleteCookie();
+			navigate('/member/withdrawl/confirm');
+		},
+	});
 	const openBottomSheetWithDrawl = () => {
 		setIsBottomSheetWithDrawlOpen(true);
 	};
@@ -19,7 +32,7 @@ const Withdrawl = () => {
 	};
 
 	const withdrawlConfirmBtn = () => {
-		navigate('/member/withdrawl/confirm');
+		mutation.mutate({ reason: String(selectReason) });
 	};
 	return (
 		<div>
@@ -30,7 +43,7 @@ const Withdrawl = () => {
 					onClose={closeBottomSheetWithDrawl}
 					viewHeight="calc(100vh * 0.45)"
 				>
-					<WithdrawlReasons />
+					<WithdrawlReasons closeFunc={closeBottomSheetWithDrawl} />
 				</BottomSheet>
 				<div className="w-[90%] mx-auto mt-11 font-body font-medium text-descGray">
 					<p>서비스에 만족을 드리지 못해</p>
@@ -49,7 +62,7 @@ const Withdrawl = () => {
 						className="flex flex-row justify-between rounded-lg bg-lightGray mx-auto mt-5 mb-40 p-3 text-gray cursor-pointer"
 						onClick={openBottomSheetWithDrawl}
 					>
-						<p>탈퇴 사유 선택</p>
+						{selectReason ? <p>{selectReason}</p> : <p>탈퇴 사유 선택</p>}
 						<img src="/assets/images/dropdownArrow.svg" alt="아래로 이동" />
 					</div>
 				</div>

--- a/src/pages/mypage/component/withDrawl/WithdrawlReasons.tsx
+++ b/src/pages/mypage/component/withDrawl/WithdrawlReasons.tsx
@@ -1,13 +1,28 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { withdrawlReasonsData } from '../../../../data/withdrawlReasonsData';
+import { CloseFuncProps } from '../region/SelectBanks';
+import { useRecoilState } from 'recoil';
+import { withDrawlState } from '../../../../recoil/atom';
 
-const WithdrawlReasons = () => {
+const WithdrawlReasons = ({ closeFunc }: CloseFuncProps) => {
+	const [selectReason, setSelectReason] = useRecoilState(withDrawlState);
+	const handleSelectReason = (reason: string) => {
+		setSelectReason(reason);
+		closeFunc();
+	};
+	useEffect(() => {
+		console.log(selectReason);
+	}, [selectReason]);
 	return (
 		<div className="overflow-y-auto max-h-[100vh] scrollbar-hide">
 			<p className="text-center mb-7">탈퇴 사유 선택</p>
 			{withdrawlReasonsData.map((reason) => (
-				<div key={reason.id} className="flex flex-col mb-5">
+				<div
+					key={reason.id}
+					className="flex flex-col mb-5 cursor-pointer"
+					onClick={() => handleSelectReason(reason.withdrawlReason)}
+				>
 					<p className="mt-1">{reason.withdrawlReason}</p>
 				</div>
 			))}

--- a/src/pages/signIn/SignIn.page.tsx
+++ b/src/pages/signIn/SignIn.page.tsx
@@ -27,6 +27,7 @@ const SignIn = () => {
 		},
 		onError(err) {
 			console.error(err);
+			setError('errorEmail', { message: '이메일 및 비밀번호를 확인해주세요' });
 			throw new Error('로그인 실패');
 		},
 	});

--- a/src/pages/signUp/SignUp.page.tsx
+++ b/src/pages/signUp/SignUp.page.tsx
@@ -56,12 +56,16 @@ const SignUp = () => {
 	}, [userInfoData, setValue]);
 	const handleCheckNickName = async () => {
 		const res = await getNickName(userNickName);
-		setIsNickNameAvailable(res?.data?.data);
+		console.log(res.data);
+		setIsNickNameAvailable(res.data);
+		console.log(isNickNameAvailable);
 	};
 
 	const handleCheckEmail = async () => {
 		const res = await getEmail(userEmail);
-		setIsEmailAvailable(res?.data?.data);
+		console.log(res);
+		setIsEmailAvailable(res.data);
+		console.log(isEmailAvailable);
 	};
 	const handleSignUp = () => {
 		const userInfoData = localStorage.getItem('userInfo');
@@ -124,7 +128,7 @@ const SignUp = () => {
 								? 'border-green'
 								: 'border-borderGray'
 						} w-full h-11 rounded-xl text-m pl-2 focus:outline-none ${
-							userNickName && errors.userNickName && !isNickNameAvailable
+							(userNickName && errors.userNickName) || isNickNameAvailable
 								? 'border border-red mb-0'
 								: ''
 						}`}
@@ -169,7 +173,7 @@ const SignUp = () => {
 								? 'border-green'
 								: 'border-borderGray'
 						} w-full h-11 rounded-xl text-m  pl-2 focus:outline-none ${
-							userEmail && errors.email && !isEmailAvailable
+							(userEmail && errors.email) || isEmailAvailable
 								? 'border border-red'
 								: ''
 						}`}

--- a/src/pages/yaSignIn/YaSignIn.page.tsx
+++ b/src/pages/yaSignIn/YaSignIn.page.tsx
@@ -34,6 +34,7 @@ const YaSignIn = () => {
 		},
 		onError(err) {
 			console.error(err);
+			setError('errorEmail', { message: '이메일 및 비밀번호를 확인해주세요' });
 			throw new Error('로그인 실패');
 		},
 	});

--- a/src/recoil/atom.ts
+++ b/src/recoil/atom.ts
@@ -143,3 +143,8 @@ export const chatStatusState = atom({
 	key: 'ChatStatusState',
 	default: '',
 });
+
+export const withDrawlState = atom<string | null>({
+	key: 'withDrawlState',
+	default: null,
+});


### PR DESCRIPTION
## ☘️ 관련 이슈
closes #103 

## ☘️ Description (사진)
1. 로그인 실패 시 에러 문구 => 이 부분은 구현해서 이미 넣어뒀는데 야놀자 로그인 수정할 때 삭제한 것 같아서 다시 올렸습니다 
![캡처](https://github.com/Yanol-Market/frontend/assets/78890707/a477225b-68a8-4718-bf83-e21c4c3e43bc)
2. 마이페이지 api 연동
1) 회원탈퇴 api => 회원탈퇴 후 저장되어 있는 쿠키도 같이 삭제 됩니다.
2) 찜 목록 => 경규님 감사합니다 👍 👍 
![찜한 상품](https://github.com/Yanol-Market/frontend/assets/78890707/aed258ca-a3be-4dfc-84f8-c4581ec3dd6a)
3) 비밀번호 변경 api 
4) 프로필 수정 api 
3. 결제 페이지 수정 => 결제 페이지로 갈 때 구매자 정보를 입력하는게 아닌 수정 불가능하게 불러오기만 하게 수정 했습니다! 
![결제 유저 정보](https://github.com/Yanol-Market/frontend/assets/78890707/17544861-b994-451d-80c4-911c1640dce0)
4. 마이페이지 일부 QA 반영
1) > 말고 글자 클릭해도 페이지 이동하게 수정
5. 회원가입 , 마이페이지 시 중복조회 정상 구현




## ☘️ 유의할 점 및 ETC (optional)
결제도 같이 넣으려 했는데 꽤나 난관이 클 작업이라 생각되어서 결제 QA 반영 할 때 넣겠습니다..! 
이것저것 하다보니깐 많이 놓치기도 하는데 코드에서 문제나 테스트 중 버그 말씀해주시면 바로바로 수정하겠습니다! 
