### PR TITLE
Feat: 결제 페이지 쿼리스트링 연결 및 비밀번호 찾기 구현 

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,14 +25,15 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
 		<!-- <script src="https://cdn.iamport.kr/v1/iamport.js"></script> -->
-		<script
+		<!-- <script
 			type="text/javascript"
 			src="https://cdn.iamport.kr/js/iamport.payment-1.1.5.js"
 		></script>
 		<script
 			type="text/javascript"
 			src="https://code.jquery.com/jquery-1.12.4.min.js"
-		></script>
+		></script> -->
+		<script src="https://cdn.iamport.kr/v1/iamport.js"></script>
 		<title>골든티켓</title>
 	</head>
 	<body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import { ChatPage } from './pages/chat';
 import ExpiredProdDetail from './pages/mypage/component/salesHistory/ExpiredProdDetail';
 import { NotFoundPage } from './component/common/NotFound';
 import { Splash } from './pages/splash';
+import { FindPassword } from './pages/findPassword';
 
 function App() {
 	return (
@@ -48,6 +49,7 @@ function App() {
 					<Route path="/splash" element={<Splash />} />
 					<Route path="/" element={<Main />} />
 					<Route path="/signin" element={<SignIn />} />
+					<Route path="/findpassword" element={<FindPassword />} />
 					<Route path="/yasignin" element={<YaSignIn />} />
 					<Route path="/signup" element={<SignUp />} />
 					<Route path="/alarm" element={<Alarm />} />

--- a/src/apis/findEmail.ts
+++ b/src/apis/findEmail.ts
@@ -1,0 +1,13 @@
+import { instanceNoToken } from './axios';
+
+export interface FindEmailProps {
+	email: string;
+}
+export const findEmail = async (data: FindEmailProps) => {
+	try {
+		const res = await instanceNoToken.post('/users/reset-password', data);
+	} catch (err) {
+		console.error(err);
+		throw new Error('비밀번호 찾기 실패');
+	}
+};

--- a/src/pages/alarm/Alarm.page.tsx
+++ b/src/pages/alarm/Alarm.page.tsx
@@ -3,8 +3,10 @@ import { Header } from '../../component/common/Header';
 import { useQueryAlarm } from '../../hooks/useQuertAlarm';
 import { AlertRes } from '../../type/alarm';
 import { formatTimeAgo } from '../../utils/formate';
+import useSignInChecked from '../../utils/useSignInChecked';
 
 const Alarm = () => {
+	useSignInChecked();
 	const { data, error } = useQueryAlarm();
 	console.log(data);
 	if (error) {

--- a/src/pages/findPassword/FindPassword.page.tsx
+++ b/src/pages/findPassword/FindPassword.page.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Header } from '../../component/common/Header';
+import { useForm } from 'react-hook-form';
+import { useMutation } from '@tanstack/react-query';
+import { findEmail } from '../../apis/findEmail';
+import { useNavigate } from 'react-router-dom';
+
+const FindPassword = () => {
+	const {
+		register,
+		handleSubmit,
+		watch,
+		setValue,
+		formState: { errors }, // isSubmitting, isDirty, isValid
+	} = useForm({ mode: 'onChange' });
+	const navigate = useNavigate();
+	const findEmailText = watch('fintEmail');
+
+	const mutation = useMutation({
+		mutationFn: findEmail,
+		onSuccess() {
+			alert('임시 비밀번호가 발급되었습니다. 이메일을 확인해주세요');
+			navigate('/signin');
+		},
+		onError() {
+			alert('유저 정보가 존재하지 않습니다.');
+		},
+	});
+
+	const handleFindEmail = () => {
+		if (findEmailText) {
+			return;
+		}
+		const data = { email: findEmailText };
+		mutation.mutate(data);
+	};
+	return (
+		<div className="w-full">
+			<Header title="비밀번호 찾기" />
+			<form className="w-[90%] mx-auto">
+				<p className="text-start text-lg font-medium mt-11 mb-5">
+					가입할 떄 사용한 이메일을 입력하시면 <br />
+					임시 비밀번호를 발송해드립니다.
+				</p>
+				<div className="relative">
+					<input
+						className="w-full h-11 border border-borderGray rounded-xl text-m pl-2 focus:outline-none"
+						type="text"
+						placeholder="이메일"
+						{...register('findEmail', {
+							required: true,
+						})}
+					/>
+					<button
+						type="button"
+						className="absolute right-3 top-2.5 bottom-0 border border-borderGray bg-borderGray w-1/4 h-6 rounded-md text-sm"
+						onClick={handleFindEmail}
+					>
+						임시번호 받기
+					</button>
+				</div>
+			</form>
+		</div>
+	);
+};
+
+export default FindPassword;

--- a/src/pages/findPassword/index.ts
+++ b/src/pages/findPassword/index.ts
@@ -1,0 +1,3 @@
+import FindPassword from './FindPassword.page';
+
+export { FindPassword };

--- a/src/pages/reservation/Product.tsx
+++ b/src/pages/reservation/Product.tsx
@@ -3,28 +3,6 @@ import React from 'react';
 import { useRecoilValue } from 'recoil';
 import { paymentsState } from '../../recoil/atom';
 
-export const productData: PaymentProps = {
-	orderId: 1,
-	productId: 1,
-	imageUrl: '/assets/images/reserveRoom.svg',
-	accommodationName: '에코그린 리조트 호텔',
-	roomName: '스탠다드 더블',
-	reservationType: '숙박',
-	standardNumber: 1,
-	maximumNumber: 2,
-	checkInDate: '2024-01-12',
-	checkInTime: '18:15:42.1989478',
-	checkOutDate: '2024-01-13',
-	checkOutTime: '19:15:42.1989478',
-	userName: 'test',
-	phoneNumber: '010-1234-5678',
-	email: 'test@mail',
-	price: 1000,
-	fee: 50,
-	totalPrice: 1050,
-	registrationNumber: 202401051119,
-};
-
 export interface PaymentProps {
 	orderId: number;
 	productId: number;
@@ -45,6 +23,7 @@ export interface PaymentProps {
 	fee: number;
 	totalPrice: number;
 	registrationNumber: number;
+	savingPrice: number;
 }
 
 const Product = () => {
@@ -55,7 +34,9 @@ const Product = () => {
 			<div className="p-[20px]">
 				<div className="flex justify-between py-[10px]">
 					<h2 className="text-body font-bold">예약 상품</h2>
-					<p className="text-sm pt-[8px]">골든티켓 등록번호 0123456789</p>
+					<p className="text-sm pt-[8px]">
+						골든티켓 등록번호 {payData?.productId}
+					</p>
 				</div>
 				<div className="flex">
 					<img

--- a/src/pages/reservation/TermSheet.tsx
+++ b/src/pages/reservation/TermSheet.tsx
@@ -19,6 +19,7 @@ interface PgDataProps {
 	userName: string;
 }
 const TermSheet: React.FC<TermSheetProps> = ({ setTermSheet }) => {
+	const redirectURL = 'https://golden-ticket.site/reservation/complete';
 	const [checkboxes, setCheckboxes] = useState<{ [key: string]: boolean }>({
 		term1: false,
 		term2: false,
@@ -84,6 +85,7 @@ const TermSheet: React.FC<TermSheetProps> = ({ setTermSheet }) => {
 				buyer_name: pgData?.userName,
 				buyer_tel: pgData?.phoneNumber || '',
 				buyer_email: pgData?.email || '',
+				m_redirect_url: redirectURL,
 			};
 
 			try {
@@ -91,23 +93,29 @@ const TermSheet: React.FC<TermSheetProps> = ({ setTermSheet }) => {
 				window.IMP.request_pay(data, callback);
 			} catch (error) {
 				console.error('Error during payment request:', error);
+				navigate('/reservation/failure');
 			}
 		}
 	};
 
-	const callback = (response: RequestPayResponse) => {
+	const callback = async (response: RequestPayResponse) => {
 		if (response.success) {
 			try {
-				instance.post('/payments/result', {
+				const res = await instance.post('/payments/result', {
 					impUid: response.imp_uid,
 					orderId: payPreData?.orderId,
 				});
+				alert('결제 성공');
+				if (res) {
+					console.log(res.data.data);
+					navigate(
+						`/reservation/complete?chatRoomId=${res.data.data.chatRoomId}`,
+					);
+				}
 			} catch (err) {
 				console.error(err);
 				throw new Error('사후검증 실패');
 			}
-			alert('결제 성공');
-			navigate('/');
 		}
 	};
 

--- a/src/pages/reservation/Total.tsx
+++ b/src/pages/reservation/Total.tsx
@@ -27,9 +27,8 @@ const Total = () => {
 				</div>
 			</div>
 			<p className="text-m p-[10px] text-right">
-				{/* 어떤 값 넣어야할 지..? */}
 				골든 티켓을 통해{' '}
-				<strong>{payData?.price.toLocaleString('ko-KR')}</strong>
+				<strong>{payData?.savingPrice.toLocaleString('ko-KR')}</strong>
 				원을 절약했어요!
 			</p>
 		</div>

--- a/src/pages/signIn/SignIn.page.tsx
+++ b/src/pages/signIn/SignIn.page.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { useMutation } from '@tanstack/react-query';
+import ArrowBackIosNewOutlinedIcon from '@mui/icons-material/ArrowBackIosNewOutlined';
 import { Link, useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { getSignIn } from '../../apis/signin';
 import { setCookie } from '../../apis/cookie';
+import { Header } from '../../component/common/Header';
 
 const SignIn = () => {
 	const {
@@ -41,8 +43,17 @@ const SignIn = () => {
 		navigate('/signup');
 	};
 
+	const handleBackBtn = () => {
+		navigate(-1);
+	};
 	return (
 		<div className="flex flex-col items-center w-full h-screen text-center px-5">
+			<div className="flex flex-row w-full items-start mt-3 cursor-pointer">
+				<ArrowBackIosNewOutlinedIcon
+					sx={{ width: '14px' }}
+					onClick={handleBackBtn}
+				/>
+			</div>
 			<img className="mt-24" src="/assets/images/mainLogo.svg" alt="logo" />
 			<form
 				className="mt-[3.75rem] w-full"
@@ -80,10 +91,11 @@ const SignIn = () => {
 					>
 						로그인
 					</button>
-
-					<p className="text-sm text-left text-gray mt-1 cursor-pointer">
-						비밀번호를 잊으셨나요?
-					</p>
+					<Link to="/findpassword">
+						<p className="text-sm text-left text-gray mt-1 cursor-pointer">
+							비밀번호를 잊으셨나요?
+						</p>
+					</Link>
 				</div>
 			</form>
 			<div className="w-full mt-[3.75rem]">
@@ -114,6 +126,11 @@ const SignIn = () => {
 					/>
 					<span className="w-2/3 ml-2 text-center">회원가입</span>
 				</button>
+				<Link to="/">
+					<p className="mt-11 text-lg text-gray underline underline-offset-1">
+						로그인 하지 않고 둘러보게요!
+					</p>
+				</Link>
 			</div>
 		</div>
 	);

--- a/src/pages/signUp/SignUp.page.tsx
+++ b/src/pages/signUp/SignUp.page.tsx
@@ -5,6 +5,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { getNickName } from '../../apis/nickname';
 import { getEmail } from '../../apis/email';
+import { Header } from '../../component/common/Header';
 
 const SignUp = () => {
 	const {
@@ -36,7 +37,7 @@ const SignUp = () => {
 			if (userInfoData) {
 				navigate('/yasignin');
 			}
-			navigate('/');
+			navigate('/signin');
 		},
 		onError(err) {
 			console.error(err);
@@ -55,6 +56,9 @@ const SignUp = () => {
 		}
 	}, [userInfoData, setValue]);
 	const handleCheckNickName = async () => {
+		if (userNickName === '') {
+			return;
+		}
 		const res = await getNickName(userNickName);
 		console.log(res.data);
 		setIsNickNameAvailable(res.data);
@@ -62,6 +66,9 @@ const SignUp = () => {
 	};
 
 	const handleCheckEmail = async () => {
+		if (userEmail === '') {
+			return;
+		}
 		const res = await getEmail(userEmail);
 		console.log(res);
 		setIsEmailAvailable(res.data);
@@ -100,7 +107,7 @@ const SignUp = () => {
 	}, [userNickName, userEmail]);
 	return (
 		<div className="flex flex-col items-center text-center">
-			<div className="mt-7">회원가입</div>
+			<Header title="회원가입" />
 			<form className="mt-10 w-[90%]" onSubmit={handleSubmit(handleSignUp)}>
 				<input
 					className={`border border-borderGray w-full h-11 mb-4  rounded-xl text-m pl-2 focus:outline-none ${

--- a/src/utils/useSignInChecked.ts
+++ b/src/utils/useSignInChecked.ts
@@ -1,0 +1,21 @@
+/**
+ * @description 토큰 체크 여부를 통해 토큰이 없으면 로그인 창으로 가게 해줍니다! 사용하시는 컴포넌트 최상단에 선언해주시면 됩니다!
+ */
+
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getCookie } from '../apis/cookie';
+
+const useSignInChecked = () => {
+	const navigate = useNavigate();
+	useEffect(() => {
+		const accessToken = getCookie('accessToken');
+		if (!accessToken) {
+			navigate('/signin');
+		}
+	}, []);
+
+	return null;
+};
+
+export default useSignInChecked;


### PR DESCRIPTION
## ☘️ 관련 이슈
closes #111 

## ☘️ Description (사진)
1. 비밀번호 찾기 기능 구현 -> 서은님이 꼭 구현됐으면 좋겠다 해서 아까 급하게 연동해봤습니다..! 이메일 입력하면 임시 비밀번호 발급 되는 것 같아요! 
2. 결제페이지에서 chatRoomId 쿼리스트링으로 전달 
3. m_redirect url 추가 -> 모바일 결제 되는지 한 번 테스트 해봐야 알 것 같습니다..ㅠ 
4. 로그인/회원가입 QA 일부 수정 
5. 토큰 없으면 바로 로그인창으로 가는 커스텀 훅 제작했습니다. @hhjs2 효주님 알람 페이지에서 최상단에 선언했는데 잘 되는 것 같아요..! 
## ☘️ 유의할 점 및 ETC (optional)
<!-- 팀원이 유의해야할 변경 사항이나 로직 및 기타 사항이 생겼다면 적어주세요. -->
