### PR TITLE
Fix: 관심 지역 바텀시트 스크롤화 및 찜한 상품 상태값 보여주기 구현

### DIFF
--- a/src/apis/deleteAccounts.ts
+++ b/src/apis/deleteAccounts.ts
@@ -1,21 +1,24 @@
-import instance from "./axios";
+import Swal from 'sweetalert2';
+import instance from './axios';
 interface DeleteAccountsProps {
-    bankName: string;
-    accountNumber: string;
+	bankName: string;
+	accountNumber: string;
 }
-export const deleteAccounts = async (data:DeleteAccountsProps) => {
-    try{
-        const res = await instance.delete('/users/account', {
-            data: {
-                bankName: data.bankName,
-                accountNumber: data.accountNumber,
-            }
-        })
-        if(res.status===200){
-            alert('계좌 삭제 완료');
-        }
-    } catch(err){
-throw new Error('계좌 삭제 실패');
-    }
-   
-}
+export const deleteAccounts = async (data: DeleteAccountsProps) => {
+	try {
+		const res = await instance.delete('/users/account', {
+			data: {
+				bankName: data.bankName,
+				accountNumber: data.accountNumber,
+			},
+		});
+		if (res.status === 200) {
+			Swal.fire({
+				title: '계좌 삭제 완료',
+				icon: 'success',
+			});
+		}
+	} catch (err) {
+		throw new Error('계좌 삭제 실패');
+	}
+};

--- a/src/apis/paymentPrepare.ts
+++ b/src/apis/paymentPrepare.ts
@@ -3,7 +3,6 @@ import instance from './axios';
 export const paymentPrePare = async (orderId: number) => {
 	try {
 		const res = await instance.post(`/payments/${orderId}/prepare`);
-		// response body로 숙소 내역을 전달 받아서 검증 해줬습니다.
 		if (res) {
 			return res.data;
 		}

--- a/src/apis/signout.ts
+++ b/src/apis/signout.ts
@@ -1,3 +1,4 @@
+import Swal from 'sweetalert2';
 import instance from './axios';
 import { deleteCookie } from './cookie';
 
@@ -16,7 +17,10 @@ export const getSignOut = async (data: SignOutProps) => {
 		});
 		if (res.status === 200) {
 			deleteCookie();
-			alert('로그아웃 완료');
+			Swal.fire({
+				title: '로그아웃 성공',
+				icon: 'success',
+			});
 		} else {
 			console.error('로그아웃 실패');
 		}

--- a/src/apis/signup.ts
+++ b/src/apis/signup.ts
@@ -1,3 +1,4 @@
+import Swal from 'sweetalert2';
 import instance, { instanceNoToken } from './axios';
 
 export interface SignUpProps {
@@ -14,7 +15,10 @@ export interface SignUpProps {
 export const getSignUp = async (data: SignUpProps) => {
 	try {
 		const res = await instanceNoToken.post('/users', data);
-		alert('회원가입 성공');
+		Swal.fire({
+			title: '회원가입 성공',
+			icon: 'success',
+		});
 		return res.data;
 	} catch (err) {
 		console.error('회원가입 실패', err);

--- a/src/apis/wishes.ts
+++ b/src/apis/wishes.ts
@@ -2,7 +2,7 @@ import axios from './axios';
 
 export const getWishes = async () => {
 	try {
-		const res = await axios.get('/products/wish'); // 임시 수정
+		const res = await axios.get('/products/wish');
 		if (res) {
 			return res.data;
 		}

--- a/src/component/common/BottomSheet/BottomSheet.tsx
+++ b/src/component/common/BottomSheet/BottomSheet.tsx
@@ -37,7 +37,7 @@ const BottomSheet = ({
 						animate={isOpen ? { height: viewHeight } : { height: 0 }}
 						exit={{ height: 0 }}
 						transition={{ type: 'anticipate', stiffness: 200, damping: 20 }}
-						className="absolute bottom-0 left-0 right-0 bg-white p-4 w-full max-w-[430px] sm:w-[430px]  mx-auto rounded-t-3xl z-50 overflow-hidden "
+						className="fixed bottom-0 left-0 right-0 bg-white p-4 w-full max-w-[430px] sm:w-[430px]  mx-auto rounded-t-3xl z-50 overflow-hidden "
 					>
 						<img
 							src="/assets/images/closeModal.svg"

--- a/src/pages/findPassword/FindPassword.page.tsx
+++ b/src/pages/findPassword/FindPassword.page.tsx
@@ -4,14 +4,13 @@ import { useForm } from 'react-hook-form';
 import { useMutation } from '@tanstack/react-query';
 import { findEmail } from '../../apis/findEmail';
 import { useNavigate } from 'react-router-dom';
+import Swal from 'sweetalert2';
 
 const FindPassword = () => {
 	const {
 		register,
-		handleSubmit,
 		watch,
-		setValue,
-		formState: { errors }, // isSubmitting, isDirty, isValid
+		formState: { errors },
 	} = useForm({ mode: 'onChange' });
 	const navigate = useNavigate();
 	const findEmailText = watch('findEmail');
@@ -19,11 +18,18 @@ const FindPassword = () => {
 	const mutation = useMutation({
 		mutationFn: findEmail,
 		onSuccess() {
-			alert('임시 비밀번호가 발급되었습니다. 이메일을 확인해주세요');
+			Swal.fire({
+				title: '임시 비밀번호가 발급되었습니다. 이메일을 확인해주세요',
+				icon: 'success',
+			});
 			navigate('/signin');
 		},
 		onError() {
 			alert('유저 정보가 존재하지 않습니다.');
+			Swal.fire({
+				title: '유저 정보가 존재하지 않습니다.',
+				icon: 'error',
+			});
 		},
 	});
 

--- a/src/pages/mypage/component/account/AddMyAccount.tsx
+++ b/src/pages/mypage/component/account/AddMyAccount.tsx
@@ -10,6 +10,7 @@ import MyPageClickBtn from '../btn/MyPageClickBtn';
 import { useMutation } from '@tanstack/react-query';
 import { patchAccounts } from '../../../../apis/patchAccounts';
 import { useNavigate } from 'react-router-dom';
+import Swal from 'sweetalert2';
 
 const AddMyAccount = () => {
 	const {
@@ -42,7 +43,10 @@ const AddMyAccount = () => {
 	const mutation = useMutation({
 		mutationFn: patchAccounts,
 		onSuccess(data) {
-			alert('계좌 등록 성공');
+			Swal.fire({
+				title: '계좌 등록 성공',
+				icon: 'success',
+			});
 			navigate(-1);
 		},
 	});

--- a/src/pages/mypage/component/account/AddMyAccount.tsx
+++ b/src/pages/mypage/component/account/AddMyAccount.tsx
@@ -16,7 +16,7 @@ const AddMyAccount = () => {
 		register,
 		handleSubmit,
 		watch,
-		formState: { errors }, // isSubmitting, isDirty, isValid
+		formState: { errors },
 	} = useForm({ mode: 'onChange' });
 	const myProfileJSON = localStorage.getItem('userProfileInfo');
 	const myProfile = JSON.parse(myProfileJSON as string);

--- a/src/pages/mypage/component/account/ManageAccount.tsx
+++ b/src/pages/mypage/component/account/ManageAccount.tsx
@@ -17,8 +17,12 @@ const ManageAccount = () => {
 		mutationFn: getSignOut,
 		onSuccess() {
 			const userProfileInfo = localStorage.getItem('userProfileInfo');
+			const userInfo = localStorage.getItem('userInfo');
 			if (userProfileInfo) {
 				localStorage.removeItem('userProfileInfo');
+			}
+			if (userInfo){
+				localStorage.removeItem('userInfo');
 			}
 			navigate('/signin');
 		},

--- a/src/pages/mypage/component/account/ManageAccount.tsx
+++ b/src/pages/mypage/component/account/ManageAccount.tsx
@@ -6,6 +6,7 @@ import ContentTwoBtnPage from '../../../../component/common/BottomSheet/Content/
 import { getCookie } from '../../../../apis/cookie';
 import { useMutation } from '@tanstack/react-query';
 import { getSignOut } from '../../../../apis/signout';
+import Swal from 'sweetalert2';
 
 const ManageAccount = () => {
 	const navigate = useNavigate();
@@ -22,7 +23,10 @@ const ManageAccount = () => {
 			navigate('/signin');
 		},
 		onError(err) {
-			alert('로그아웃 실패');
+			Swal.fire({
+				title: '로그아웃 실패',
+				icon: 'error',
+			});
 		},
 	});
 

--- a/src/pages/mypage/component/account/MyAccount.tsx
+++ b/src/pages/mypage/component/account/MyAccount.tsx
@@ -10,11 +10,12 @@ import { deleteAccounts } from '../../../../apis/deleteAccounts';
 import NotFoundContent from '../content/NotFoundContent';
 import { getAccounts } from '../../../../apis/getAccounts';
 import { getCookie } from '../../../../apis/cookie';
+import { Loading } from '../../../../component/common/Loading';
 
 const MyAccount = () => {
 	const navigate = useNavigate();
 	const accessToken = getCookie('accessToken');
-	const { data } = useQuery({
+	const { data, isLoading } = useQuery({
 		queryKey: ['getAccounts'],
 		queryFn: getAccounts,
 		enabled: !!accessToken,
@@ -52,6 +53,7 @@ const MyAccount = () => {
 
 	return (
 		<div>
+			{isLoading && <Loading />}
 			{data?.data.bankName && data?.data.accountNumber ? (
 				<>
 					<Header title="내 계좌" />

--- a/src/pages/mypage/component/content/BottomSheetRegionContent.tsx
+++ b/src/pages/mypage/component/content/BottomSheetRegionContent.tsx
@@ -22,11 +22,10 @@ const BottomSheetRegionContent = ({
 		},
 		[checkedList, setCheckedList],
 	);
-	console.log(checkedList);
 	return (
-		<div className="flex flex-col justify-center">
+		<div className="flex flex-col justify-center h-full overflow-scroll scrollbar-hide">
 			<p className="text-center mb-7">관심지역 선택</p>
-			<div className="">
+			<div className="overflow-scroll scrollbar-hide">
 				{regionData &&
 					regionData.map((regions) => (
 						<div

--- a/src/pages/mypage/component/content/BottomSheetRegionContent.tsx
+++ b/src/pages/mypage/component/content/BottomSheetRegionContent.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { regionData } from '../../../../data/regionData';
 import { useRecoilState } from 'recoil';
 import { checkedListState } from '../../../../recoil/atom';
+import Swal from 'sweetalert2';
 
 interface BottomSheetRegionContentProps {
 	onClick: () => void;
@@ -17,7 +18,10 @@ const BottomSheetRegionContent = ({
 			} else if (checkedList.length < 3) {
 				setCheckedList((prev) => [...prev, item]);
 			} else {
-				console.log('3개 이상 추가할 수 없습니다');
+				Swal.fire({
+					title: '3개 이상 등록 할 수 없습니다.',
+					icon: 'warning',
+				});
 			}
 		},
 		[checkedList, setCheckedList],

--- a/src/pages/mypage/component/edit/EditPassword.tsx
+++ b/src/pages/mypage/component/edit/EditPassword.tsx
@@ -7,6 +7,7 @@ import MyPageClickBtn from '../btn/MyPageClickBtn';
 import { useMutation } from '@tanstack/react-query';
 import { patchPassword } from '../../../../apis/patchPassword';
 import { useNavigate } from 'react-router-dom';
+import Swal from 'sweetalert2';
 
 const EditPassword = () => {
 	const {
@@ -40,7 +41,10 @@ const EditPassword = () => {
 	const mutation = useMutation({
 		mutationFn: patchPassword,
 		onSuccess() {
-			alert('비밀번호 변경 성공');
+			Swal.fire({
+				title: '비밀번호 변경 성공',
+				icon: 'success',
+			});
 			navigate('/member/editpassword/confirm');
 		},
 		onError() {

--- a/src/pages/mypage/component/edit/ProfileEdit.tsx
+++ b/src/pages/mypage/component/edit/ProfileEdit.tsx
@@ -22,6 +22,7 @@ const ProfileEdit = () => {
 	const [myNicknameAvailable, setMyNickNameAvailable] = useState(null);
 	const currentNickName = watch('currentNickName');
 	const isButtonDisabled = myNicknameAvailable === null || myNicknameAvailable === true || !currentNickName
+	const isNickNameCheckDisabled = (currentNickName && errors.currentNickName)
 	useEffect(() => {
 		setValue('currentNickName', myProfile.data.nickname);
 	}, [myProfile.data.nickname, setValue]);
@@ -66,6 +67,7 @@ const ProfileEdit = () => {
 									className={`border border-borderGray absolute cursor-pointer ${myNicknameAvailable === null || myNicknameAvailable ? 'border border-main bg-main text-white' : 'bg-borderGray' } right-2 top-[2.5rem] w-14 h-6 bg-borderGray text-sm text-descGray rounded-md`}
 									type="button"
 									onClick={handleCheckNickName}
+									disabled={isNickNameCheckDisabled}
 								>
 									중복 확인
 								</button>

--- a/src/pages/mypage/component/edit/ProfileEdit.tsx
+++ b/src/pages/mypage/component/edit/ProfileEdit.tsx
@@ -14,14 +14,14 @@ const ProfileEdit = () => {
 		handleSubmit,
 		watch,
 		setValue,
-		formState: { errors }, // isSubmitting, isDirty, isValid
+		formState: { errors },
 	} = useForm({ mode: 'onChange' });
 	const navigate = useNavigate();
 	const myProfileJSON = localStorage.getItem('userProfileInfo');
 	const myProfile = JSON.parse(myProfileJSON as string);
 	const [myNicknameAvailable, setMyNickNameAvailable] = useState(null);
 	const currentNickName = watch('currentNickName');
-	const isButtonDisabled = !myNicknameAvailable;
+	const isButtonDisabled = myNicknameAvailable === null || myNicknameAvailable === true || !currentNickName
 	useEffect(() => {
 		setValue('currentNickName', myProfile.data.nickname);
 	}, [myProfile.data.nickname, setValue]);
@@ -60,10 +60,10 @@ const ProfileEdit = () => {
 				<div className="w-[90%] mt-14">
 					<form>
 						<div className="relative">
-							<div className="flex flex-row justify-between font-bold">
+							<div className="flex flex-row justify-between">
 								<p className="text-lg">닉네임</p>
 								<button
-									className="border border-borderGray absolute cursor-pointer right-2 top-[2.5rem] w-14 h-6 bg-borderGray text-sm text-[#828282] rounded-md"
+									className={`border border-borderGray absolute cursor-pointer ${myNicknameAvailable === null || myNicknameAvailable ? 'border border-main bg-main text-white' : 'bg-borderGray' } right-2 top-[2.5rem] w-14 h-6 bg-borderGray text-sm text-descGray rounded-md`}
 									type="button"
 									onClick={handleCheckNickName}
 								>
@@ -78,7 +78,7 @@ const ProfileEdit = () => {
 										? 'border-green'
 										: 'border-borderGray'
 								} w-full h-11 rounded-xl text-botton mt-2 bg-lightGray pl-4 focus:outline-none ${
-									(currentNickName && errors.email) || myNicknameAvailable
+									(currentNickName && errors.currentNickName) || myNicknameAvailable
 										? 'border border-red'
 										: ''
 								}`}
@@ -129,7 +129,7 @@ const ProfileEdit = () => {
 						<MyPageClickBtn
 							content="변경사항 저장하기"
 							onClick={handleProfileEdit}
-							isDisabled={!isButtonDisabled}
+							isDisabled={isButtonDisabled}
 						/>
 					</form>
 				</div>

--- a/src/pages/mypage/component/edit/ProfileEdit.tsx
+++ b/src/pages/mypage/component/edit/ProfileEdit.tsx
@@ -6,6 +6,7 @@ import { useMutation } from '@tanstack/react-query';
 import { putNickName } from '../../../../apis/putNickname';
 import { useNavigate } from 'react-router';
 import { getNickName } from '../../../../apis/nickname';
+import Swal from 'sweetalert2';
 
 const ProfileEdit = () => {
 	const {
@@ -28,7 +29,10 @@ const ProfileEdit = () => {
 	const mutation = useMutation({
 		mutationFn: putNickName,
 		onSuccess() {
-			alert('프로필 수정 성공');
+			Swal.fire({
+				title: '프로필 수정 성공',
+				icon: 'success',
+			});
 			navigate('/');
 		},
 	});

--- a/src/pages/mypage/component/region/InterestRegion.tsx
+++ b/src/pages/mypage/component/region/InterestRegion.tsx
@@ -11,6 +11,7 @@ import { getInterestRegions } from '../../../../apis/getInterestRegions';
 import { convertRegionCode } from '../../../../utils/convertRegionCode';
 import { getCookie, refreshCookie } from '../../../../apis/cookie';
 import { Loading } from '../../../../component/common/Loading';
+import Swal from 'sweetalert2';
 
 interface WishRegionProps {
 	id: number;
@@ -37,7 +38,10 @@ const InterestRegion = () => {
 	const mutation = useMutation({
 		mutationFn: postInterestRegion,
 		onSuccess() {
-			alert('관심 지역 등록 성공');
+			Swal.fire({
+				title: '관심지역 등록 성공',
+				icon: 'success',
+			});
 			closeBottomSheet();
 			window.location.reload();
 		},

--- a/src/pages/mypage/component/region/InterestRegion.tsx
+++ b/src/pages/mypage/component/region/InterestRegion.tsx
@@ -10,6 +10,7 @@ import { postInterestRegion } from '../../../../apis/postInterestRegion';
 import { getInterestRegions } from '../../../../apis/getInterestRegions';
 import { convertRegionCode } from '../../../../utils/convertRegionCode';
 import { getCookie, refreshCookie } from '../../../../apis/cookie';
+import { Loading } from '../../../../component/common/Loading';
 
 interface WishRegionProps {
 	id: number;
@@ -42,11 +43,10 @@ const InterestRegion = () => {
 		},
 	});
 
-	const { data, isError } = useQuery<InterestRegionProps>({
+	const { data, isLoading } = useQuery<InterestRegionProps>({
 		queryKey: ['getInterestRegions'],
 		queryFn: getInterestRegions,
 	});
-	console.log(data?.data);
 	const convertedWishRegions = data?.data?.wishRegions.map(
 		(region: WishRegionProps) => {
 			return {
@@ -63,6 +63,7 @@ const InterestRegion = () => {
 	};
 	return (
 		<div>
+			{isLoading && <Loading />}
 			<Header title="관심 지역" />
 			<div className="flex flex-col items-center">
 				<BottomSheet

--- a/src/pages/mypage/component/region/SelectBanks.tsx
+++ b/src/pages/mypage/component/region/SelectBanks.tsx
@@ -12,9 +12,6 @@ const SelectBanks = ({ closeFunc }: CloseFuncProps) => {
 		setSelectBank(bank);
 		closeFunc();
 	};
-	// useEffect(() => {
-	// 	console.log(selectBank);
-	// }, [selectBank]); // useEffect 안 쓰면 console.log가 두 번 실행됨.
 
 	return (
 		<div className="overflow-scroll h-full scrollbar-hide">

--- a/src/pages/mypage/component/service/ProfilePolicies.tsx
+++ b/src/pages/mypage/component/service/ProfilePolicies.tsx
@@ -5,7 +5,6 @@ import { ServiceTextData } from '../../../../data/ServiceTextData';
 import { profileServiceData } from '../../../../data/profileServiceData';
 
 const ProfilePolicies = () => {
-	const textlines = ServiceTextData.split('\n');
 	return (
 		<div>
 			<Header title="개인정보 처리방침" />

--- a/src/pages/mypage/component/wishes/WishItem.tsx
+++ b/src/pages/mypage/component/wishes/WishItem.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { formatDate } from '../../../../utils/b';
 import { useNavigate } from 'react-router-dom';
 import { deleteWish } from '../../../../apis/wish';
+import { productStatusAlertTitle } from '../../../products/component/ProductInfo';
 export interface WishItemProps {
 	accommodationImage: string;
 	accommodationName: string;
@@ -44,7 +45,7 @@ export const WishItem = ({ product }: { product: WishItemProps }) => {
 							alt="ic_calendar"
 						/>
 						<pre className="text-[5px] text-center text-white">
-							{/* {productStatusAlertTitle(product.status as string)} */}
+							{productStatusAlertTitle(product.status as string)}
 						</pre>
 					</div>
 				)}

--- a/src/pages/mypage/component/wishes/WishList.tsx
+++ b/src/pages/mypage/component/wishes/WishList.tsx
@@ -5,6 +5,7 @@ import { getWishes } from '../../../../apis/wishes';
 import { ProductSpecialType } from '../../../main/component/Product/ProductListSpecial';
 import { Header } from '../../../../component/common/Header';
 import { WishItem, WishItemProps } from './WishItem';
+import { Loading } from '../../../../component/common/Loading';
 
 export interface WishListProps {
 	accommodationImage: string;
@@ -23,12 +24,13 @@ export interface WishListProps {
 	yanoljaPrice: number;
 }
 const WishList = () => {
-	const { data } = useQuery({
+	const { data, isLoading } = useQuery({
 		queryKey: ['wishes'],
 		queryFn: getWishes,
 	});
 	return (
 		<div>
+			{isLoading && <Loading />}
 			<Header title="찜한 상품" />
 			{data?.data?.wishProducts &&
 				data?.data?.wishProducts.map((item: WishItemProps) => (

--- a/src/pages/mypage/component/withDrawl/WithdrawlReasons.tsx
+++ b/src/pages/mypage/component/withDrawl/WithdrawlReasons.tsx
@@ -11,11 +11,8 @@ const WithdrawlReasons = ({ closeFunc }: CloseFuncProps) => {
 		setSelectReason(reason);
 		closeFunc();
 	};
-	useEffect(() => {
-		console.log(selectReason);
-	}, [selectReason]);
 	return (
-		<div className="overflow-y-auto max-h-[100vh] scrollbar-hide">
+		<div className="overflow-y-auto h-full scrollbar-hide">
 			<p className="text-center mb-7">탈퇴 사유 선택</p>
 			{withdrawlReasonsData.map((reason) => (
 				<div

--- a/src/pages/reservation/Failure.tsx
+++ b/src/pages/reservation/Failure.tsx
@@ -19,7 +19,7 @@ const Failure = () => {
 			<div className="flex gap-[15px] m-[20px]">
 				<button
 					onClick={() => navigate('/')}
-					className="w-[90%] h-[50px] bg-[#004EAF] rounded-[12px] text-white text-lg"
+					className="w-full h-[50px] bg-[#004EAF] rounded-[12px] text-white text-lg"
 				>
 					확인
 				</button>

--- a/src/pages/reservation/Payment.tsx
+++ b/src/pages/reservation/Payment.tsx
@@ -8,31 +8,7 @@ const Payment: React.FC<PaymentProps> = ({ setPayment }) => {
 	return (
 		<div className="px-[10px]">
 			<h2 className="text-body font-bold mb-[5px] p-[10px]">결제 수단</h2>
-			<div className="text-center flex flex-wrap justify-center text-lg gap-x-[17px] gap-y-[15px]">
-				{/* <input
-					type="radio"
-					id="credit"
-					value="카드결제"
-					name="payment"
-					className="hidden"
-					onChange={(event) => setPayment(event.target.value)}
-				/>
-				<label
-					htmlFor="credit"
-					className="flex flex-col justify-center w-[95%] h-[50px] border-[1px] border-[#e5e5e5] rounded-[12px] text-[#828282] bg-[#FAFAFA] hover:bg-[#FFF3C5] hover:text-black hover:font-semibold hover:border-[#FFF3C5] cursor-pointer"
-				>
-					카드결제
-				</label>
-				<style type="text/css">
-					{`
-                        input#credit:checked + label {
-                        color: black;
-                        background-color: #FFF3C5;
-                        border: 1px solid #FFF3C5;
-                        }
-                    `}
-				</style> */}
-			</div>
+			<div className="text-center flex flex-wrap justify-center text-lg gap-x-[17px] gap-y-[15px]"></div>
 		</div>
 	);
 };

--- a/src/pages/reservation/Product.tsx
+++ b/src/pages/reservation/Product.tsx
@@ -28,7 +28,6 @@ export interface PaymentProps {
 
 const Product = () => {
 	const payData = useRecoilValue(paymentsState);
-	console.log(payData);
 	return (
 		<>
 			<div className="p-[20px]">

--- a/src/pages/reservation/TermSheet.tsx
+++ b/src/pages/reservation/TermSheet.tsx
@@ -41,11 +41,8 @@ const TermSheet: React.FC<TermSheetProps> = ({ setTermSheet }) => {
 	const mutation = useMutation({
 		mutationFn: paymentPrePare,
 		onSuccess(data) {
-			console.log('paymentPrePare 함수 호출 후 데이터 :', data.data);
-			console.log('결제 준비 완료');
 			if (data.data) {
 				handlePayment(data.data);
-				console.log('handlePayment 함수 실행 완료');
 			}
 		},
 		onError(err) {
@@ -55,7 +52,6 @@ const TermSheet: React.FC<TermSheetProps> = ({ setTermSheet }) => {
 	});
 
 	const onClickPayment = () => {
-		console.log('payPreData: ', payPreData);
 		if (payPreData) {
 			mutation.mutate(payPreData.orderId);
 		}
@@ -82,7 +78,6 @@ const TermSheet: React.FC<TermSheetProps> = ({ setTermSheet }) => {
 		if (!window.IMP) return;
 
 		if (impCode) {
-			console.log(impCode);
 			window.IMP.init(impCode);
 			const data: RequestPayParams = {
 				pg: 'html5_inicis.INIBillTst',
@@ -97,9 +92,7 @@ const TermSheet: React.FC<TermSheetProps> = ({ setTermSheet }) => {
 			};
 
 			try {
-				console.log('Payment data:', data);
 				window.IMP.request_pay(data, callback);
-				console.log('KG결제창 완료');
 			} catch (error) {
 				console.error('결제 중 발생한 에러:', error);
 				navigate('/reservation/failure');
@@ -108,14 +101,12 @@ const TermSheet: React.FC<TermSheetProps> = ({ setTermSheet }) => {
 	};
 
 	const callback = async (response: RequestPayResponse) => {
-		console.log(response);
 		if (response.success) {
 			try {
 				const res = await instance.post('/payments/result', {
 					impUid: response.imp_uid,
 					orderId: payPreData?.orderId,
 				});
-				console.log(res);
 				if (res) {
 					const sendMessages = async () => {
 						const data1 = {
@@ -141,19 +132,13 @@ const TermSheet: React.FC<TermSheetProps> = ({ setTermSheet }) => {
 
 						try {
 							const result1 = await sendMessage(data1);
-							console.log('첫 번째 메시지 전송 결과:', result1);
-
 							const result2 = await sendMessage(data2);
-							console.log('두 번째 메시지 전송 결과:', result2);
-
 							const result3 = await sendMessage(data3);
-							console.log('세 번째 메시지 전송 결과:', result3);
 						} catch (error) {
 							console.error('메시지 전송 중 오류 발생:', error);
 						}
 					};
 					sendMessages();
-					console.log('사후검증 후 응답받는 값: ', res.data.data);
 					if (res.data.data.result === 'SUCCESS') {
 						navigate(
 							`/reservation/complete?chatRoomId=${res.data.data.chatRoomId}`,
@@ -171,7 +156,6 @@ const TermSheet: React.FC<TermSheetProps> = ({ setTermSheet }) => {
 				throw new Error('사후검증 실패');
 			}
 		} else {
-			console.log('결제 실패');
 			navigate('/reservation/failure');
 		}
 	};

--- a/src/pages/reservation/index.tsx
+++ b/src/pages/reservation/index.tsx
@@ -10,9 +10,6 @@ const ReservationPage = () => {
 	const [payment, setPayment] = useState('');
 	const [termSheet, setTermSheet] = useState(false);
 	const isDisabled = !!payment;
-
-	console.log(payment, isDisabled, termSheet);
-
 	return (
 		<div className="relative">
 			<Header title="결제하기" />

--- a/src/pages/signIn/SignIn.page.tsx
+++ b/src/pages/signIn/SignIn.page.tsx
@@ -13,7 +13,7 @@ const SignIn = () => {
 		handleSubmit,
 		watch,
 		setError,
-		formState: { errors }, // isSubmitting, isDirty, isValid
+		formState: { errors },
 	} = useForm({ mode: 'onChange' });
 
 	const userId = watch('userid');

--- a/src/pages/signUp/SignUp.page.tsx
+++ b/src/pages/signUp/SignUp.page.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { getNickName } from '../../apis/nickname';
 import { getEmail } from '../../apis/email';
 import { Header } from '../../component/common/Header';
+import Swal from 'sweetalert2';
 
 const SignUp = () => {
 	const {
@@ -51,7 +52,10 @@ const SignUp = () => {
 		},
 		onError(err) {
 			console.error(err);
-			alert('이미 가입된 계정입니다. 로그인을 해주세요.');
+			Swal.fire({
+				title: '이미 가입된 계정입니다. 로그인을 해주세요.',
+				icon: 'error',
+			});
 			navigate('/signin');
 			throw new Error('회원가입 실패');
 		},
@@ -70,9 +74,7 @@ const SignUp = () => {
 			return;
 		}
 		const res = await getNickName(userNickName);
-		console.log(res.data);
 		setIsNickNameAvailable(res.data);
-		console.log(isNickNameAvailable);
 	};
 
 	const handleCheckEmail = async () => {
@@ -80,9 +82,7 @@ const SignUp = () => {
 			return;
 		}
 		const res = await getEmail(userEmail);
-		console.log(res);
 		setIsEmailAvailable(res.data);
-		console.log(isEmailAvailable);
 	};
 	const handleSignUp = () => {
 		const userInfoData = localStorage.getItem('userInfo');

--- a/src/pages/signUp/SignUp.page.tsx
+++ b/src/pages/signUp/SignUp.page.tsx
@@ -46,9 +46,10 @@ const SignUp = () => {
 		mutationFn: getSignUp,
 		onSuccess(data) {
 			if (userInfoData) {
-				navigate('/yasignin');
+				navigate('/');
+			}else{
+				navigate('/signin');
 			}
-			navigate('/signin');
 		},
 		onError(err) {
 			console.error(err);

--- a/src/pages/signUp/SignUp.page.tsx
+++ b/src/pages/signUp/SignUp.page.tsx
@@ -39,7 +39,8 @@ const SignUp = () => {
 		!userEmail ||
 		!userPassword ||
 		!userpasswordChecked;
-
+ const isNickNameCheckDisabled = (userNickName && errors.userNickName);
+ const isEmailCheckDisabled = (userEmail && errors.userEmail);
 	const userInfoData = localStorage.getItem('userInfo');
 	const navigate = useNavigate();
 	const mutation = useMutation({
@@ -169,6 +170,7 @@ const SignUp = () => {
 								: 'bg-borderGray'
 						} border border-borderGray bg-borderGray w-1/4 h-6 rounded-md text-sm focus:outline-none`}
 						onClick={handleCheckNickName}
+						disabled={isNickNameCheckDisabled}
 					>
 						중복 확인
 					</button>
@@ -217,6 +219,7 @@ const SignUp = () => {
 								: 'bg-borderGray'
 						} border border-borderGray bg-borderGray w-1/4 h-6 rounded-md text-sm focus:outline-none`}
 						onClick={handleCheckEmail}
+						disabled={isEmailCheckDisabled}
 					>
 						중복 확인
 					</button>

--- a/src/pages/yaSignIn/YaSignIn.page.tsx
+++ b/src/pages/yaSignIn/YaSignIn.page.tsx
@@ -12,7 +12,7 @@ const YaSignIn = () => {
 		handleSubmit,
 		watch,
 		setError,
-		formState: { errors }, // isSubmitting, isDirty, isValid
+		formState: { errors },
 	} = useForm({ mode: 'onChange' });
 	const yaUserId = watch('yauserid');
 	const yaUserPassword = watch('yauserpassword');


### PR DESCRIPTION
## ☘️ 관련 이슈
closes #159 

## ☘️ Description (사진)
1. 관심지역 , 회원탈퇴 바텀시트 스크롤 가능하게 구현
2. console.log 제거
3. SweetAlert2 적용
4. useQuery로 데이터 받아올 시 로딩중 컴포넌트 적용 (@hhjs2  👍 👍 )
5. 야놀자 최초 로그인 시 회원가입 후 다시 로그인페이지로 가는 것 수정
6. 프로필 수정 버튼 비활성화 적용

## ☘️ 유의할 점 및 ETC (optional)
제발 마지막 PR이길... 다들 파이널 너무너무 고생 많으셨습니다 👍 👍 
