### PR TITLE
Fix: 관심지역 체크리스트 Recoil-persist 적용

### DIFF
--- a/src/pages/mypage/component/content/BottomSheetRegionContent.tsx
+++ b/src/pages/mypage/component/content/BottomSheetRegionContent.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { regionData } from '../../../../data/regionData';
 import { useRecoilState } from 'recoil';
 import { checkedListState } from '../../../../recoil/atom';
@@ -14,9 +14,11 @@ const BottomSheetRegionContent = ({
 	const onCheckedItem = useCallback(
 		(item: string) => {
 			if (checkedList.includes(item)) {
-				setCheckedList((prev) => prev.filter((el) => el !== item));
+				setCheckedList((prev: string[]) =>
+					prev.filter((el: string) => el !== item),
+				);
 			} else if (checkedList.length < 3) {
-				setCheckedList((prev) => [...prev, item]);
+				setCheckedList((prev: string[]) => [...prev, item]);
 			} else {
 				Swal.fire({
 					title: '3개 이상 등록 할 수 없습니다.',
@@ -26,6 +28,9 @@ const BottomSheetRegionContent = ({
 		},
 		[checkedList, setCheckedList],
 	);
+	useEffect(() => {
+		console.log(checkedList);
+	}, [checkedList]);
 	return (
 		<div className="flex flex-col justify-center h-full overflow-scroll scrollbar-hide">
 			<p className="text-center mb-7">관심지역 선택</p>

--- a/src/recoil/atom.ts
+++ b/src/recoil/atom.ts
@@ -5,7 +5,10 @@ import { recoilPersist } from 'recoil-persist';
 import { PaymentProps } from '../pages/reservation/Product';
 import { ProductData } from '../pages/chat/Chat.page';
 
-const { persistAtom } = recoilPersist();
+const { persistAtom } = recoilPersist({
+	key: 'localStorageRecoil',
+	storage: localStorage,
+});
 const toDay = new Date();
 const sevenDaysLater = new Date();
 sevenDaysLater.setDate(toDay.getDate() + 6);
@@ -26,6 +29,7 @@ export const checkedState = atom({
 export const checkedListState = atom({
 	key: 'checkedListState',
 	default: [] as string[],
+	effects_UNSTABLE: [persistAtom],
 });
 
 export interface SelectBanksProps {
@@ -182,11 +186,10 @@ export const isShowState = atom<boolean>({
 });
 export const dateRefState = atom({
 	key: 'dateRefState',
-	default: null
+	default: null,
 });
 
 export const negoAvailableState = atom<boolean>({
 	key: 'negoAvailableState',
 	default: false,
 });
-


### PR DESCRIPTION
## ☘️ 관련 이슈
closes #170 

## ☘️ Description (사진)
관심 지역을 선택할 때 아이콘이 변경되지 않는 에러
-> 에러라기보단 새로 관심지역 조회할 때 새로고침 하게 했는데 이렇게 되니 recoil로 관리했던 상태가 초기화되어서 아이콘이 적용이 안되는 문제가 발생했습니다! 
-> recoil-persist로 로컬스토리지로 관리하게 했습니다.

## ☘️ 유의할 점 및 ETC (optional)
정말정말정말 마지막 PR이면 좋겠어요..ㅠ 다들 고생하셨습니다 👍 👍 
